### PR TITLE
Fix prefix should always start a slash

### DIFF
--- a/src/SectionConfiguration.php
+++ b/src/SectionConfiguration.php
@@ -174,10 +174,6 @@ final class SectionConfiguration
 
         $prefix = mb_strtolower(trim($prefix, '/'));
 
-        if ('' === $prefix || '/' !== mb_substr($prefix, -1)) {
-            $prefix .= '/';
-        }
-
-        return $prefix;
+        return '' === $prefix ? '/' : "/$prefix/";
     }
 }

--- a/src/SectionsConfigurator.php
+++ b/src/SectionsConfigurator.php
@@ -216,8 +216,8 @@ final class SectionsConfigurator
 
     private function findNoneMatchingPath(string $currentPrefix, string $otherPrefix): string
     {
-        $prefix = array_filter(explode('/', $currentPrefix));
-        $prefixes = array_filter(explode('/', $otherPrefix));
+        $prefix = array_filter(explode('/', trim($currentPrefix, '/')));
+        $prefixes = array_filter(explode('/', trim($otherPrefix, '/')));
         $matches = false;
 
         foreach ($prefixes as $i => $secondaryPrefix) {

--- a/tests/SectionConfigurationTest.php
+++ b/tests/SectionConfigurationTest.php
@@ -81,10 +81,10 @@ final class SectionConfigurationTest extends TestCase
      */
     public function it_converts_the_prefix_to_lowercase_and_ensures_slashes()
     {
-        $this->assertEquals('something/', (new SectionConfiguration('Example.com/Something'))->prefix);
-        $this->assertEquals('something/', (new SectionConfiguration('Example.com/Something/'))->prefix);
-        $this->assertEquals('something/', (new SectionConfiguration('/Something/'))->prefix);
-        $this->assertEquals('foo/', (new SectionConfiguration('/foo'))->prefix);
+        $this->assertEquals('/something/', (new SectionConfiguration('Example.com/Something'))->prefix);
+        $this->assertEquals('/something/', (new SectionConfiguration('Example.com/Something/'))->prefix);
+        $this->assertEquals('/something/', (new SectionConfiguration('/Something/'))->prefix);
+        $this->assertEquals('/foo/', (new SectionConfiguration('/foo'))->prefix);
 
         // Note. foo/ assumes foo is the host. Make sure the prefix always begins with a /
     }

--- a/tests/SectioningFactoryTest.php
+++ b/tests/SectioningFactoryTest.php
@@ -49,7 +49,7 @@ final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'defaults' => [],
                     'requirements' => [],
                     'path' => '^/backend/',

--- a/tests/SectionsConfiguratorTest.php
+++ b/tests/SectionsConfiguratorTest.php
@@ -38,7 +38,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'client/',
+                    'prefix' => '/client/',
                     'path' => '^/client/',
                     'requirements' => [],
                     'defaults' => [],
@@ -48,7 +48,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => 'example.com',
                     'domain' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -121,7 +121,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -131,7 +131,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'api/',
+                    'prefix' => '/api/',
                     'path' => '^/api/',
                     'requirements' => [],
                     'defaults' => [],
@@ -169,7 +169,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -179,7 +179,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'api/backend/',
+                    'prefix' => '/api/backend/',
                     'path' => '^/api/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -189,7 +189,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'host' => null,
                     'domain' => null,
                     'host_pattern' => null,
-                    'prefix' => 'api/',
+                    'prefix' => '/api/',
                     'path' => '^/api/(?!(backend)/)',
                     'requirements' => [],
                     'defaults' => [],
@@ -227,7 +227,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -237,7 +237,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'api/backend/',
+                    'prefix' => '/api/backend/',
                     'path' => '^/api/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -247,7 +247,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'api/',
+                    'prefix' => '/api/',
                     'path' => '^/api/(?!(backend)/)',
                     'requirements' => [],
                     'defaults' => [],
@@ -285,7 +285,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'backend/',
+                    'prefix' => '/backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -295,7 +295,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'api/backend/',
+                    'prefix' => '/api/backend/',
                     'path' => '^/api/backend/',
                     'requirements' => [],
                     'defaults' => [],
@@ -305,7 +305,7 @@ final class SectionsConfiguratorTest extends TestCase
                     'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
-                    'prefix' => 'api/',
+                    'prefix' => '/api/',
                     'path' => '^/api/(?!(backend)/)',
                     'requirements' => [],
                     'defaults' => [],
@@ -368,7 +368,7 @@ final class SectionsConfiguratorTest extends TestCase
         $this->assertEquals('^example\.(?P<tld>com|net)$', $container->getParameter('acme.section.backend.host_pattern'));
         $this->assertEquals(['tld' => 'com'], $container->getParameter('acme.section.backend.defaults'));
         $this->assertEquals(['tld' => 'com|net'], $container->getParameter('acme.section.backend.requirements'));
-        $this->assertEquals('backend/', $container->getParameter('acme.section.backend.prefix'));
+        $this->assertEquals('/backend/', $container->getParameter('acme.section.backend.prefix'));
         $this->assertEquals('^/backend/', $container->getParameter('acme.section.backend.path'));
 
         $requestMatcherFrontend = $container->getDefinition('acme.section.frontend.request_matcher');
@@ -447,7 +447,7 @@ final class SectionsConfiguratorTest extends TestCase
         $failedSections = [
             // primary => [host, prefix, conflicts]
             'first' => ['^example\.com$', '/', ['second', 'third']],
-            'first1' => ['', 'foo/', ['second2']],
+            'first1' => ['', '/foo/', ['second2']],
         ];
 
         $expectedMessage = ValidatorException::sectionsConfigConflict($failedSections)->getMessage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

A prefix should always start a `/` to ensure the SecurityBundle detects it's as a path and not a route.